### PR TITLE
workflow: including ssh to cron job

### DIFF
--- a/workflow.sh
+++ b/workflow.sh
@@ -21,6 +21,10 @@ touch $LOCKFILE
 # Redirect stdout and stderr to the log file
 exec > >(tee -a $LOGFILE) 2>&1
 
+# Start the SSH agent
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+
 # Log the current branch before switching
 ORIGINAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 echo "Current branch before switch: $ORIGINAL_BRANCH"

--- a/workflow.sh
+++ b/workflow.sh
@@ -45,11 +45,11 @@ echo "Activating virtual environment..."
 source ~/Projects/database_from_Bitcoin_Core/venv/bin/activate
 
 # Run the populate scripts
-echo "Running populate_blocks.py..."
+echo "Running population scripts..."
 python -u src/blocks/populate_blocks.py
 
 # Run the data quality checks
-echo "Running blocks_dq.py..."
+echo "Running DQ scripts..."
 python -u src/blocks/blocks_dq.py
 python -u src/transactions/transactions_dq.py
 


### PR DESCRIPTION
cron runs in its own environment, and although the testing is successful when running from the shell, cron doesn't have access to the ssh keys, and that's why we need to add them.